### PR TITLE
SystemUI: statusbar: Add battery temperature to LS

### DIFF
--- a/packages/SystemUI/res/values/custom_config.xml
+++ b/packages/SystemUI/res/values/custom_config.xml
@@ -29,6 +29,9 @@
     <!-- The CPU temperature sensor path, defaults to empty -->
     <string name="config_cpuTempSensor" translatable="false"></string>
 
+    <!-- The battery temperature divider, if needed -->
+    <integer name="config_battTempDivider" translatable="false">10</integer>
+
     <!-- The CPU temperature divider, if needed -->
     <integer name="config_cpuTempDivider" translatable="false">1</integer>
 

--- a/packages/SystemUI/res/values/custom_strings.xml
+++ b/packages/SystemUI/res/values/custom_strings.xml
@@ -114,6 +114,8 @@
     <string name="tuner_keyguard_show_watt_summary">Show charging watts value</string>
     <string name="tuner_keyguard_show_current_title">Show charging current</string>
     <string name="tuner_keyguard_show_current_summary">Show charging current values</string>
+    <string name="tuner_keyguard_show_battery_temp_title">Show battery temperature</string>
+    <string name="tuner_keyguard_show_battery_temp_summary">Show battery temperature value</string>
     <string name="tuner_keyguard_show_battery_bar_title">Show battery bar</string>
     <string name="tuner_keyguard_show_battery_bar_summary">Show battery bar on charging in always on display</string>
     <string name="tuner_keyguard_show_battery_bar_always_title">Always show battery bar</string>

--- a/packages/SystemUI/res/xml/lockscreen_settings.xml
+++ b/packages/SystemUI/res/xml/lockscreen_settings.xml
@@ -58,6 +58,12 @@
         sysui:defValue="false" />
 
     <com.android.systemui.tuner.TunerSwitch
+        android:key="sysui_keyguard_show_battery_temp"
+        android:title="@string/tuner_keyguard_show_battery_temp_title"
+        android:summary="@string/tuner_keyguard_show_battery_temp_summary"
+        sysui:defValue="false" />
+
+    <com.android.systemui.tuner.TunerSwitch
         android:key="sysui_keyguard_show_battery_bar"
         android:title="@string/tuner_keyguard_show_battery_bar_title"
         android:summary="@string/tuner_keyguard_show_battery_bar_summary"

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -29,6 +29,7 @@ import static android.os.BatteryManager.EXTRA_MAX_CHARGING_VOLTAGE;
 import static android.os.BatteryManager.EXTRA_VOLTAGE;
 import static android.os.BatteryManager.EXTRA_PLUGGED;
 import static android.os.BatteryManager.EXTRA_STATUS;
+import static android.os.BatteryManager.EXTRA_TEMPERATURE;
 
 import android.annotation.AnyThread;
 import android.annotation.MainThread;
@@ -781,6 +782,7 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
                 final int level = intent.getIntExtra(EXTRA_LEVEL, 0);
                 final int health = intent.getIntExtra(EXTRA_HEALTH, BATTERY_HEALTH_UNKNOWN);
 
+                double currBatteryTemp = intent.getIntExtra(EXTRA_TEMPERATURE, -1);
                 final int maxChargingMicroAmp = intent.getIntExtra(EXTRA_MAX_CHARGING_CURRENT, -1);
                 int maxChargingMicroVolt = intent.getIntExtra(EXTRA_MAX_CHARGING_VOLTAGE, -1);
                 double currChargingVoltage = intent.getIntExtra(EXTRA_VOLTAGE, -1);
@@ -800,10 +802,10 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
                 }
                 if (DEBUG) Log.d(TAG, "maxChargingMicroAmp = " + maxChargingMicroAmp +
                         " maxChargingMicroVolt = " + maxChargingMicroVolt + " maxChargingMicroWatt = " +
-                        maxChargingMicroWatt);
+                        maxChargingMicroWatt + " currBatteryTemp = " + currBatteryTemp);
                 final Message msg = mHandler.obtainMessage(
                         MSG_BATTERY_UPDATE, new BatteryStatus(status, level, plugged, health,
-                                maxChargingMicroWatt, currChargingVoltage));
+                                maxChargingMicroWatt, currChargingVoltage, currBatteryTemp));
                 mHandler.sendMessage(msg);
             } else if (TelephonyIntents.ACTION_SIM_STATE_CHANGED.equals(action)) {
                 SimData args = SimData.fromIntent(intent);
@@ -1007,14 +1009,16 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
         public final int health;
         public final int maxChargingWattage;
         public final double currChargingVolt;
+        public final double currBatteryTemp;
         public BatteryStatus(int status, int level, int plugged, int health,
-                int maxChargingWattage, double currChargingVolt) {
+                int maxChargingWattage, double currChargingVolt, double currBatteryTemp) {
             this.status = status;
             this.level = level;
             this.plugged = plugged;
             this.health = health;
             this.maxChargingWattage = maxChargingWattage;
             this.currChargingVolt = currChargingVolt;
+            this.currBatteryTemp = currBatteryTemp;
         }
 
         /**
@@ -1201,7 +1205,7 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener {
         }
 
         // Take a guess at initial SIM state, battery status and PLMN until we get an update
-        mBatteryStatus = new BatteryStatus(BATTERY_STATUS_UNKNOWN, 100, 0, 0, 0, 0);
+        mBatteryStatus = new BatteryStatus(BATTERY_STATUS_UNKNOWN, 100, 0, 0, 0, 0, 0);
 
         // Watch for interesting updates
         final IntentFilter filter = new IntentFilter();

--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -98,7 +98,10 @@ public class KeyguardIndicationController {
     private int mChargingSpeed;
     private int mChargingWattage;
     private double mChargingVolt;
+    private double mBatteryTemp;
     private int mBatteryLevel;
+    private int mBatteryTempDivider;
+    private boolean mShowBatteryTemp;
     private boolean mShowChargingWatts;
     private boolean mShowChargingCurrent;
     private String mMessageToShowOnScreenOn;
@@ -113,6 +116,7 @@ public class KeyguardIndicationController {
     private static final String KEYGUARD_SHOW_CURRENT_ON_CHARGING = "sysui_keyguard_show_current";
     private static final String KEYGUARD_SHOW_BATTERY_BAR = "sysui_keyguard_show_battery_bar";
     private static final String KEYGUARD_SHOW_BATTERY_BAR_ALWAYS = "sysui_keyguard_show_battery_bar_always";
+    private static final String KEYGUARD_SHOW_BATTERY_TEMP = "sysui_keyguard_show_battery_temp";
 
     private BatteryBarView mBatteryBar;
 
@@ -306,16 +310,21 @@ public class KeyguardIndicationController {
         }
 
         if (mVisible) {
+            mShowBatteryTemp = Dependency.get(TunerService.class)
+                    .getValue(KEYGUARD_SHOW_BATTERY_TEMP, 0) == 1;
             mShowChargingWatts = Dependency.get(TunerService.class)
-                .getValue(KEYGUARD_SHOW_WATT_ON_CHARGING, 0) == 1;
+                    .getValue(KEYGUARD_SHOW_WATT_ON_CHARGING, 0) == 1;
             mShowChargingCurrent = Dependency.get(TunerService.class)
-                .getValue(KEYGUARD_SHOW_CURRENT_ON_CHARGING, 0) == 1;
+                    .getValue(KEYGUARD_SHOW_CURRENT_ON_CHARGING, 0) == 1;
+            mBatteryTempDivider = mContext.getResources()
+                    .getInteger(R.integer.config_battTempDivider);
 
             final boolean showBatteryBar = Dependency.get(TunerService.class)
                     .getValue(KEYGUARD_SHOW_BATTERY_BAR, 1) == 1;
             final boolean showBatteryBarAlways = Dependency.get(TunerService.class)
                     .getValue(KEYGUARD_SHOW_BATTERY_BAR_ALWAYS, 0) == 1;
-            final boolean showPowerDetails = mShowChargingWatts || mShowChargingCurrent;
+            final boolean showPowerDetails =
+                    mShowChargingWatts || mShowChargingCurrent || mShowBatteryTemp;
 
             // Walk down a precedence-ordered list of what indication
             // should be shown based on user or device state
@@ -424,19 +433,29 @@ public class KeyguardIndicationController {
             return "";
         }
 
-        final StringBuilder powerString = new StringBuilder();
+        final StringBuilder powerString = new StringBuilder("\n");
+        final String SPACER = " • ";
 
         if (mShowChargingWatts) {
-            powerString.append(", ");
             powerString.append(String.format("%.1f", (float) mChargingWattage / 1000000));
             powerString.append(" W");
         }
         if (mShowChargingCurrent) {
-            powerString.append(", ");
+            if (mShowChargingWatts) {
+                powerString.append(SPACER);
+            }
             powerString.append(String.format("%.3f", mChargingVolt / 1000));
-            powerString.append(" V, ");
+            powerString.append(" V");
+            powerString.append(SPACER);
             powerString.append(Math.round(mChargingWattage / mChargingVolt));
             powerString.append(" mA");
+        }
+        if (mShowBatteryTemp) {
+            if (mShowChargingWatts || mShowChargingCurrent) {
+                powerString.append(SPACER);
+            }
+            powerString.append(String.format("%.1f", (float) mBatteryTemp / mBatteryTempDivider));
+            powerString.append(" °C");
         }
         return powerString.toString();
     }
@@ -544,6 +563,8 @@ public class KeyguardIndicationController {
         pw.println("  mPowerCharged: " + mPowerCharged);
         pw.println("  mChargingSpeed: " + mChargingSpeed);
         pw.println("  mChargingWattage: " + mChargingWattage);
+        pw.println("  mChargingVolt: " + mChargingVolt);
+        pw.println("  mBatteryTemp: " + mBatteryTemp);
         pw.println("  mMessageToShowOnScreenOn: " + mMessageToShowOnScreenOn);
         pw.println("  mDozing: " + mDozing);
         pw.println("  mBatteryLevel: " + mBatteryLevel);
@@ -563,6 +584,7 @@ public class KeyguardIndicationController {
             mPowerPluggedInWired = status.isPluggedInWired() && isChargingOrFull;
             mPowerPluggedIn = status.isPluggedIn() && isChargingOrFull;
             mPowerCharged = status.isCharged();
+            mBatteryTemp = status.currBatteryTemp;
             mChargingWattage = status.maxChargingWattage;
             mChargingVolt = status.currChargingVolt;
             mChargingSpeed = status.getChargingSpeed(mSlowThreshold, mFastThreshold);


### PR DESCRIPTION
Temperature divider can be overriden in device overlay:

<integer name="config_battTempDivider" translatable="false">10</integer>

Also move all charging details one seperate line below and pretti-fy output.

Change-Id: I14d1f6c6e27ecf0bdf3081fa968021ed01eade9d